### PR TITLE
chore: ✨ gitignore .beads/ (central beads at meta/ level)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Beads issue tracker (local, not committed)
+.beads/


### PR DESCRIPTION
## Summary

- Add `.beads/` to `.gitignore` so that the central beads store at the `meta/` level is not tracked inside individual sub-repos.

## Test plan

- [ ] Verify `.beads/` is excluded from `git status` output in this sub-repo after creation.